### PR TITLE
Handle variable turn according to SD2

### DIFF
--- a/segment.py
+++ b/segment.py
@@ -22,6 +22,7 @@ class Segment:
         arc = None
         radius = None
         end_radius = None
+        profil_steps_length = None
         for attr in ele.childNodes:
             if attr.nodeType == Node.ELEMENT_NODE:
                 if attr.getAttribute('name') == 'type':
@@ -38,19 +39,23 @@ class Segment:
                 if attr.getAttribute('name') == 'lg':
                     assert attr.getAttribute('unit') == 'm', attr.getAttribute('unit')
                     length = float(attr.getAttribute('val'))
+                if attr.getAttribute('name') == 'profil steps length':
+                    assert attr.getAttribute('unit') == 'm', attr.getAttribute('unit')
+                    profil_steps_length = float(attr.getAttribute('val'))
 
         assert seg_type in ['lft', 'str', 'rgt'], seg_type
         if seg_type == 'rgt':
             arc = -arc
-        return Segment(name, length, arc, radius, end_radius)
+        return Segment(name, length, arc, radius, end_radius, profil_steps_length)
 
     def __init__(self, name=None, length=None, arc=None, radius=None,
-                 end_radius=None):
+                 end_radius=None, profil_steps_length=None):
         self.name = name
         self.length = length
         self.arc = arc
         self.radius = radius
         self.end_radius = end_radius
+        self.profil_steps_length = profil_steps_length
 
     def __str__(self):
         return "Segment('{}', {}, {}, {})".format(self.name, self.length,

--- a/test_segment.py
+++ b/test_segment.py
@@ -1,5 +1,6 @@
 import unittest
 import math
+from xml.dom.minidom import parseString
 
 from segment import Segment
 
@@ -75,5 +76,44 @@ class SegmentTest(unittest.TestCase):
     def test_segment_str(self):
         s = Segment(name='s11', length=10)
         self.assertEqual(str(s), "Segment('s11', 10, None, None)")
+
+    def test_from_xml(self):
+        xmldoc = parseString("""
+      <section name="s6">
+        <attstr name="type" val="lft" />
+        <attnum name="arc" unit="deg" val="102.0" />
+        <attnum name="radius" unit="m" val="32.7" />
+        <attnum name="end radius" unit="m" val="38.4" />
+        <attnum name="grade" unit="%" val="-3.0" />
+        <attnum name="profil end tangent" unit="%" val="-3.0" />
+        <attnum name="profil steps length" unit="m" val="4.0" />
+        <attnum name="banking start" unit="deg" val="0.0"/>
+        <attnum name="banking end" unit="deg" val="-4.0"/>
+        <attstr name="marks" val="50;100;150"/>
+        <section name="Left Border">
+          <attnum name="width" unit="m" val="1.0" />
+          <attnum name="height" unit="m" val="0.05" />
+          <attstr name="surface" val="curb-left" />
+          <attstr name="style" val="curb" />
+        </section>
+        <section name="Left Side">
+          <attnum name="start width" unit="m" val="10.0" />
+          <attnum name="end width" unit="m" val="12.0" />
+          <attstr name="surface" val="dirtA" />
+        </section>
+        <section name="Right Side">
+          <attnum name="start width" unit="m" val="32.0" />
+          <attnum name="end width" unit="m" val="40.0" />
+          <attstr name="surface" val="sand" />
+        </section>
+      </section>
+""")
+        s = Segment.from_xml(xmldoc.childNodes[0])
+        self.assertEqual(s.name, 's6')
+        self.assertIsNone(s.length)
+        self.assertAlmostEqual(math.degrees(s.arc), 102.0)
+        self.assertAlmostEqual(s.radius, 32.7)
+        self.assertAlmostEqual(s.end_radius, 38.4)
+        self.assertAlmostEqual(s.profil_steps_length, 4.0)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Note, that in Speed Dreams 2 is variable turn in reality just composite
of several turns with fixed radius. The length step is used from the
parameter "profil steps length".

This solution is simple "brute force" where original segment is split into several "ordinary" with fixed radius.

Fixes #21.