### PR TITLE
Compute the nearest segment for the whole track

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -86,7 +86,6 @@ if __name__ == "__main__":
         sys.exit(2)
     filename = sys.argv[1]
     track = Track.from_xml_file(filename)
-    track.width = 100  # extra margin
     drive(track)
 
 # vim: expandtab sw=4 ts=4

--- a/test_track.py
+++ b/test_track.py
@@ -29,8 +29,7 @@ class TrackTest(unittest.TestCase):
         line = Segment(length=100.0)
         arc = Segment(arc=math.radians(180), radius=10.0)
 
-        # note, that width is artifically set to overlap
-        track = Track([line, arc]*2, width = 100)
+        track = Track([line, arc]*2, width = 10)
         segment, rel_pose = track.nearest_segment((50, 15, math.radians(180)))
         self.assertIsNone(segment.arc)
         self.assertAlmostEqual(rel_pose[2], 0.0)

--- a/test_track.py
+++ b/test_track.py
@@ -25,4 +25,14 @@ class TrackTest(unittest.TestCase):
         self.assertIsNotNone(segment)
         self.assertAlmostEqual(segment.length, 100.0)
 
+    def test_nearest_segment(self):
+        line = Segment(length=100.0)
+        arc = Segment(arc=math.radians(180), radius=10.0)
+
+        # note, that width is artifically set to overlap
+        track = Track([line, arc]*2, width = 100)
+        segment, rel_pose = track.nearest_segment((50, 15, math.radians(180)))
+        self.assertIsNone(segment.arc)
+        self.assertAlmostEqual(rel_pose[2], 0.0)
+
 # vim: expandtab sw=4 ts=4

--- a/track.py
+++ b/track.py
@@ -110,6 +110,8 @@ class Track:
         """Find nearest segment on the track"""
         global_x, global_y, global_a = pose
         track_pose = 0, 0, 0
+        best = None, None
+        best_dist = None
         for segment in self.segments:
             # convert global (x,y) into pose relative coordinates
             x, y, a = track_pose
@@ -119,9 +121,14 @@ class Track:
             sx, sy = ca*sx - sa*sy, sa*sx + ca*sy
             dist = segment.get_offset((sx, sy, global_a - a))[0]
             if dist is not None:
-                if abs(dist) < self.width/2.0:
-                    return segment, (sx, sy, global_a - a)
+                if best_dist is None or abs(dist) < best_dist:
+                    best = segment, (sx, sy, global_a - a)
+                    best_dist = abs(dist)
             track_pose = segment.step(track_pose)
+
+        if best_dist is not None:
+            if best_dist < self.width/2.0:
+                return best
         return None, None
 
     def get_offset(self, pose):

--- a/track.py
+++ b/track.py
@@ -125,11 +125,7 @@ class Track:
                     best = segment, (sx, sy, global_a - a)
                     best_dist = abs(dist)
             track_pose = segment.step(track_pose)
-
-        if best_dist is not None:
-            if best_dist < self.width/2.0:
-                return best
-        return None, None
+        return best
 
     def get_offset(self, pose):
         segment, rel_pose = self.nearest_segment(pose)

--- a/track.py
+++ b/track.py
@@ -107,7 +107,18 @@ class Track:
         self.width = width
 
     def nearest_segment(self, pose):
-        """Find nearest segment on the track"""
+        """Find nearest segment on the track
+        
+        Return segment and relative pose to the segment
+
+        This method can return (None, None) when:
+        - there is no segment in the ``Track.segments``
+        - the ``pose`` is outside of the scope for each
+          segment
+
+        For the valid closed loop track you should always get values
+        other than (None, None).        
+        """
         global_x, global_y, global_a = pose
         track_pose = 0, 0, 0
         best = None, None


### PR DESCRIPTION
There was a problem with "aalborg" with close sharp turns. Currently we have original track width enlarged to 100m, so the vehicle can find the way back to original track. This PR fixes it.