### PR TITLE
Add badges to readme for travis and appveyor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pyroborace
+![Python: v2.7](https://img.shields.io/badge/python-v2.7-blue.svg)
 [![Build Status: Linux](https://img.shields.io/travis/robotika/pyroborace/master.svg?style=plastic&label=linux tests)](https://travis-ci.org/robotika/pyroborace)
 [![Build Status: Windows](https://img.shields.io/appveyor/ci/robotika/pyroborace/master.svg?style=plastic&label=windows tests)](https://ci.appveyor.com/project/robotika/pyroborace)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # pyroborace
+[![Build Status: Linux](https://img.shields.io/travis/robotika/pyroborace/master.svg?style=plastic)](https://travis-ci.org/robotika/pyroborace)
+[![Build Status: Windows](https://img.shields.io/appveyor/ci/zwn/pyroborace/master.svg?style=plastic)](https://ci.appveyor.com/project/zwn/pyroborace)
+
 Python driver for Formula-E Roborace
 
 The official API is not available yet, so we will start from UDP protocol

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyroborace
-[![Build Status: Linux](https://img.shields.io/travis/robotika/pyroborace/master.svg?style=plastic)](https://travis-ci.org/robotika/pyroborace)
-[![Build Status: Windows](https://img.shields.io/appveyor/ci/zwn/pyroborace/master.svg?style=plastic)](https://ci.appveyor.com/project/zwn/pyroborace)
+[![Build Status: Linux](https://img.shields.io/travis/robotika/pyroborace/master.svg?style=plastic&label=linux tests)](https://travis-ci.org/robotika/pyroborace)
+[![Build Status: Windows](https://img.shields.io/appveyor/ci/robotika/pyroborace/master.svg?style=plastic&label=windows tests)](https://ci.appveyor.com/project/robotika/pyroborace)
 
 Python driver for Formula-E Roborace
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pyroborace
-![Python: v2.7](https://img.shields.io/badge/python-v2.7-blue.svg)
+![Python: v2.7](https://img.shields.io/badge/python-v2.7-blue.svg?style=plastic)
 [![Build Status: Linux](https://img.shields.io/travis/robotika/pyroborace/master.svg?style=plastic&label=linux tests)](https://travis-ci.org/robotika/pyroborace)
 [![Build Status: Windows](https://img.shields.io/appveyor/ci/robotika/pyroborace/master.svg?style=plastic&label=windows tests)](https://ci.appveyor.com/project/robotika/pyroborace)
 


### PR DESCRIPTION
In doing so I found out that on appveyor our repo is not under robotika but under zwn. Tomorrow I'll try to find out why and change it. Please don't merge yet (I put it up so you know what I am up to).