### PR TITLE
Feature/logging

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -6,6 +6,7 @@
 """
 
 import math
+import os
 import struct
 import sys
 
@@ -89,7 +90,8 @@ if __name__ == "__main__":
         sys.exit(2)
     filename = sys.argv[1]
     track = Track.from_xml_file(filename)
-    io = IOLog()
+    prefix = os.path.splitext(os.path.basename(filename))[0]
+    io = IOLog(prefix=prefix)
     drive(io, track)
 
 # vim: expandtab sw=4 ts=4

--- a/demo.py
+++ b/demo.py
@@ -6,11 +6,12 @@
 """
 
 import math
-import socket
 import struct
 import sys
 
+from iolog import IOLog, Timeout
 from track import Track
+
 
 def segment_turn(segment):
     """Return turn angle in degrees (expected car structure input)"""
@@ -30,11 +31,10 @@ def segment_turn(segment):
     return math.degrees(angle)
 
 
-def drive(track):
-    soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+def drive(io, track):
     port = 4001
-    soc.bind(('', port))
-    soc.settimeout(1.0)
+    io.bind(('', port))
+    io.settimeout(1.0)
     ctr = 0
     gas = 0.0
     brake = 0.0
@@ -42,9 +42,9 @@ def drive(track):
     prev_segment = None
     while True:
         data = struct.pack('fffiBB', turn, gas, brake, 1, 11, ctr & 0xFF)
-        soc.sendto(data, ('127.0.0.1', 3001))
+        io.sendto(data, ('127.0.0.1', 3001))
         try:
-            status = soc.recv(1024)
+            status = io.recv(1024)
             assert len(status) == 794, len(status)
             sim_status = struct.unpack_from('B', status, 792)[0]
             if sim_status == 5: # simulation stopped
@@ -79,7 +79,7 @@ def drive(track):
                 print segment, rel_pose
                 prev_segment = segment
 
-        except socket.timeout:
+        except Timeout:
             pass
         ctr += 1
 
@@ -89,6 +89,7 @@ if __name__ == "__main__":
         sys.exit(2)
     filename = sys.argv[1]
     track = Track.from_xml_file(filename)
-    drive(track)
+    io = IOLog()
+    drive(io, track)
 
 # vim: expandtab sw=4 ts=4

--- a/demo.py
+++ b/demo.py
@@ -2,7 +2,7 @@
   follow the race loop
 
   usage:
-     demo.py <track XML file>
+     demo.py <track XML file> [<input log file>]
 """
 
 import math
@@ -10,7 +10,7 @@ import os
 import struct
 import sys
 
-from iolog import IOLog, Timeout
+from iolog import IOLog, Timeout, IOFromFile
 from track import Track
 
 
@@ -90,8 +90,13 @@ if __name__ == "__main__":
         sys.exit(2)
     filename = sys.argv[1]
     track = Track.from_xml_file(filename)
-    prefix = os.path.splitext(os.path.basename(filename))[0]
-    io = IOLog(prefix=prefix)
+
+    if len(sys.argv) == 2:
+        prefix = os.path.splitext(os.path.basename(filename))[0]
+        io = IOLog(prefix=prefix)
+    else:
+        io = IOFromFile(filename=sys.argv[2])
+
     drive(io, track)
 
 # vim: expandtab sw=4 ts=4

--- a/iolog.py
+++ b/iolog.py
@@ -2,7 +2,17 @@
   Input/Output logging
 """
 
+from datetime import datetime
+import os
 import socket
+from struct import pack
+
+
+MAGIC_HEADER = 0x492F4F01  # I/O
+VERSION = 1
+
+INPUT = 1
+OUTPUT = 0
 
 
 class Timeout(socket.timeout):
@@ -11,8 +21,14 @@ class Timeout(socket.timeout):
 
 class IOLog(object):
 
-    def __init__(self):
+    def __init__(self, prefix):
         self.soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        
+        if not os.path.exists('logs'):
+            os.mkdir('logs')
+        filename = datetime.now().strftime('logs/'+prefix+'-%y%m%d_%H%M%S.log')
+        self.f = open(filename, 'wb')
+        self.f.write(pack('II', MAGIC_HEADER, VERSION))
 
     def bind(self, address):
         self.soc.bind(address)
@@ -22,13 +38,18 @@ class IOLog(object):
 
     def sendto(self, data, address):
         try:
+            self.f.write(pack('HH', len(data) + 2, OUTPUT))
+            self.f.write(data)
             self.soc.sendto(data, address)
         except socket.timeout as e:
             raise Timeout(e)
 
     def recv(self, bufsize):
         try:
-            return self.soc.recv(bufsize)
+            data = self.soc.recv(bufsize)
+            self.f.write(pack('HH', len(data) + 2, INPUT))
+            self.f.write(data)
+            return data
         except socket.timeout as e:
             raise Timeout(e)
 

--- a/iolog.py
+++ b/iolog.py
@@ -79,4 +79,17 @@ class IOFromFile(object):
         assert length - 2 <= bufsize
         return self.f.read(length - 2)
 
+
+def packet_gen(filename):
+    f = open(filename, 'rb')
+    data = f.read(8)
+    assert unpack('II', data) == (MAGIC_HEADER, VERSION)
+    while True:
+        data = f.read(4)
+        if len(data) != 4:
+            break  # EOF
+
+        length, io_dir = unpack('HH', data)
+        yield io_dir, f.read(length - 2)
+
 # vim: expandtab sw=4 ts=4

--- a/iolog.py
+++ b/iolog.py
@@ -1,0 +1,35 @@
+"""
+  Input/Output logging
+"""
+
+import socket
+
+
+class Timeout(socket.timeout):
+    pass
+
+
+class IOLog(object):
+
+    def __init__(self):
+        self.soc = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def bind(self, address):
+        self.soc.bind(address)
+
+    def settimeout(self, value):
+        self.soc.settimeout(value)
+
+    def sendto(self, data, address):
+        try:
+            self.soc.sendto(data, address)
+        except socket.timeout as e:
+            raise Timeout(e)
+
+    def recv(self, bufsize):
+        try:
+            return self.soc.recv(bufsize)
+        except socket.timeout as e:
+            raise Timeout(e)
+
+# vim: expandtab sw=4 ts=4

--- a/packets.py
+++ b/packets.py
@@ -3,8 +3,9 @@
   usage:
      python packets.py <logfile>
 """
-import sys
+import math
 from struct import unpack_from
+import sys
 
 from iolog import packet_gen, INPUT, OUTPUT
 
@@ -43,6 +44,9 @@ class Sensors(object):
         self.dist = dist
         self.pos3d = pos3d
         self.vel3d = vel3d
+
+    def speed(self):
+        return math.sqrt(sum([x*x for x in self.vel3d]))
 
     def __str__(self):
         return 'Sensors(time={}, dist={}, pos={}, vel={})'.format(

--- a/packets.py
+++ b/packets.py
@@ -1,0 +1,66 @@
+"""
+  Interpretation of I/O UDP packets
+  usage:
+     python packets.py <logfile>
+"""
+import sys
+from struct import unpack_from
+
+from iolog import packet_gen, INPUT, OUTPUT
+
+
+class Command(object):
+    """Represent command packet for car control"""
+    
+    @staticmethod
+    def from_packet(packet):
+        assert len(packet) == 18, len(packet)
+        steering, acc, brake = unpack_from('fff', packet, 0)
+        return Command(steering, acc, brake)
+
+    def __init__(self, steering, acc, brake):
+        self.steering = steering
+        self.acc = acc
+        self.brake = brake
+
+    def __str__(self):
+        return 'Command(steering={}, acc={}, brake={})'.format(
+            self.steering, self.acc, self.brake)
+
+
+class Sensors(object):
+
+    @staticmethod
+    def from_packet(packet):
+        assert len(packet) == 794, len(packet)
+        time, dist = unpack_from('ff', packet, 0)
+        pos3d = unpack_from('fff', packet, 44)
+        vel3d = unpack_from('fff', packet, 80)
+        return Sensors(time, dist, pos3d, vel3d)
+
+    def __init__(self, time, dist, pos3d, vel3d):
+        self.time = time
+        self.dist = dist
+        self.pos3d = pos3d
+        self.vel3d = vel3d
+
+    def __str__(self):
+        return 'Sensors(time={}, dist={}, pos={}, vel={})'.format(
+                self.time, self.dist, self.pos3d, self.vel3d)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print __doc__
+        sys.exit(2)
+
+    for io_dir, packet in packet_gen(sys.argv[1]):
+        if io_dir == INPUT:
+            obj = Sensors.from_packet(packet)
+        elif io_dir == OUTPUT:
+            obj = Command.from_packet(packet)
+        else:
+            assert 0, io_dir  # unsuported type
+        print obj
+
+# vim: expandtab sw=4 ts=4

--- a/plot.py
+++ b/plot.py
@@ -2,7 +2,7 @@
 """
   Plot track data
   usage:
-       ./plot.py <track XML> [<log file>]
+       ./plot.py <track XML> [<log file> [<log file> ...]]
 """
 import sys
 from math import sin, cos, pi
@@ -92,9 +92,9 @@ if __name__ == "__main__":
     track = Track.from_xml_file(filename)
     fig = draw(track)
 
-    if len(sys.argv) > 2:
+    for filename in sys.argv[2:]:
         x, y = [], []
-        for sensors in sensors_gen(sys.argv[2]):
+        for sensors in sensors_gen(filename):
             x.append(sensors.pos3d[0])
             y.append(sensors.pos3d[1])
         plt.plot(x, y, '--')

--- a/plot.py
+++ b/plot.py
@@ -2,7 +2,7 @@
 """
   Plot track data
   usage:
-       ./plot.py <track XML>
+       ./plot.py <track XML> [<log file>]
 """
 import sys
 from math import sin, cos, pi
@@ -12,6 +12,8 @@ from matplotlib.path import Path
 import matplotlib.patches as patches
 
 from track import Track
+from packets import sensors_gen
+
 
 # Notes:
 #
@@ -88,7 +90,14 @@ if __name__ == "__main__":
 
     filename = sys.argv[1]
     track = Track.from_xml_file(filename)
-    draw(track)
+    fig = draw(track)
+
+    if len(sys.argv) > 2:
+        x, y = [], []
+        for sensors in sensors_gen(sys.argv[2]):
+            x.append(sensors.pos3d[0])
+            y.append(sensors.pos3d[1])
+        plt.plot(x, y, '--')
     plt.show()
 
 # vim: expandtab sw=4 ts=4

--- a/test_packets.py
+++ b/test_packets.py
@@ -1,0 +1,13 @@
+import unittest
+import math
+
+from packets import Command
+
+class PacketsTest(unittest.TestCase):
+
+    def test_command_from_packet(self):
+        packet = '\xce\x9d\x04\xc0\xcd\xccL>\x00\x00\x00\x00\x01\x00\x00\x00\x0b\x01'
+        cmd = Command.from_packet(packet)
+        self.assertAlmostEqual(cmd.acc, 0.2)
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is preliminary draft of I/O logging. At the moment there are data only logged with simple format: header with version and INPUT/OUTPUT header with packet length and packet data.

All logs are stored in "logs" directory and prefixed with name of the circuit.
For example `logs\espie-161208_194905.log` (size 16.2MB for 2 laps).

Relates to #8 

Should we add `--nologs` option? By default log everything? Is format OK for version 1 or do we need communication timestamps?