### PR TITLE
Feature/python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    - "2.7"
+    - "3.5"
 env:
     global:
         MPLBACKEND="agg"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - "3.5"
+    - "3.6"
 env:
     global:
         MPLBACKEND="agg"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
   matrix:
   - PYTHON: c:\python35
   - PYTHON: c:\python35-x64
+  - PYTHON: c:\python36
+  - PYTHON: c:\python36-x64
 build: off
 install:
 - cmd: '%PYTHON%\python.exe -m pip install -r requirements.txt'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ version: "{build}"
 skip_branch_with_pr: true
 environment:
   matrix:
-  - PYTHON: c:\python27
-  - PYTHON: c:\python27-x64
+  - PYTHON: c:\python35
+  - PYTHON: c:\python35-x64
 build: off
 install:
 - cmd: '%PYTHON%\python.exe -m pip install -r requirements.txt'

--- a/demo.py
+++ b/demo.py
@@ -77,7 +77,7 @@ def drive(io, track):
                     turn += max(-max_dist_turn_deg, dead_band - signed_dist)
 
             if prev_segment != segment:
-                print segment, rel_pose
+                print(segment, rel_pose)
                 prev_segment = segment
 
         except Timeout:
@@ -86,7 +86,7 @@ def drive(io, track):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print __doc__
+        print(__doc__)
         sys.exit(2)
     filename = sys.argv[1]
     track = Track.from_xml_file(filename)

--- a/packets.py
+++ b/packets.py
@@ -67,7 +67,7 @@ def sensors_gen(filename):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print __doc__
+        print(__doc__)
         sys.exit(2)
 
     for io_dir, packet in packet_gen(sys.argv[1]):
@@ -77,6 +77,6 @@ if __name__ == "__main__":
             obj = Command.from_packet(packet)
         else:
             assert 0, io_dir  # unsuported type
-        print obj
+        print(obj)
 
 # vim: expandtab sw=4 ts=4

--- a/plot.py
+++ b/plot.py
@@ -85,7 +85,7 @@ def draw(track):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print __doc__
+        print(__doc__)
         sys.exit(2)
 
     filename = sys.argv[1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 cycler==0.10.0
 matplotlib==1.5.3
-numpy==1.11.2
+numpy==1.12.0
 pyparsing==2.1.10
 python-dateutil==2.6.0
 pytz==2016.7

--- a/test_packets.py
+++ b/test_packets.py
@@ -6,7 +6,7 @@ from packets import Command
 class PacketsTest(unittest.TestCase):
 
     def test_command_from_packet(self):
-        packet = '\xce\x9d\x04\xc0\xcd\xccL>\x00\x00\x00\x00\x01\x00\x00\x00\x0b\x01'
+        packet = b'\xce\x9d\x04\xc0\xcd\xccL>\x00\x00\x00\x00\x01\x00\x00\x00\x0b\x01'
         cmd = Command.from_packet(packet)
         self.assertAlmostEqual(cmd.acc, 0.2)
 

--- a/track.py
+++ b/track.py
@@ -42,9 +42,9 @@ def print_track(track):
         else:
             length += segment.arc * segment.radius
             # TODO variable turns
-        print segment.name
-    print
-    print math.degrees(angle), length
+        print(segment.name)
+    print()
+    print(math.degrees(angle), length)
 
 
 def track2xy(track):
@@ -152,20 +152,20 @@ class Track:
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print __doc__
+        print(__doc__)
         sys.exit(2)
     path = sys.argv[1]
     if path.endswith('xml'):
-        print path
+        print(path)
         track = Track.from_xml_file(path)
-        print track2xy(track.segments)
+        print(track2xy(track.segments))
     else:
         for dirpath, dirnames, filenames in os.walk(path):
             for filename in filenames:
                 if filename.endswith('xml'):
                     track = Track.from_xml_file(os.path.join(dirpath, filename))
                     end_pose = track2xy(track.segments)
-                    print filename, end_pose
+                    print(filename, end_pose)
                     assert abs(end_pose[0]) + abs(end_pose[1]) < 0.5, end_pose
                     deg_angle = int(round(math.degrees(end_pose[2])))
                     assert deg_angle in [-360, 0, 360], deg_angle


### PR DESCRIPTION
Conversion from Python 2.7 to Python 3.5 is implemented (#11) Surprisingly it was quite easy (only print statements and one binary test string/data), so I am suspicious that something is omitted.

Split into 3 commits was partially on purpose - I wanted to check, that testing framework will fail and then after fixup work, but I would probably squeeze it all into one commit.